### PR TITLE
Fix #14: Server config "doVoiding" work properly

### DIFF
--- a/src/main/java/mod/traister101/sns/util/handlers/PickupHandler.java
+++ b/src/main/java/mod/traister101/sns/util/handlers/PickupHandler.java
@@ -169,11 +169,8 @@ public final class PickupHandler {
 			remainder = ItemHandlerHelper.insertItem(maybeContainerInv.get(), remainder, false);
 
 			if (remainder.isEmpty()) return ItemStack.EMPTY;
-			if (SNSConfig.SERVER.doVoiding.get() && !ContainerType.canDoItemVoiding(itemContainer)) continue;
-
+			if (!SNSConfig.SERVER.doVoiding.get() || !ContainerType.canDoItemVoiding(itemContainer)) continue;
 			if (!voidedItem(remainder, maybeContainerInv.get())) return ItemStack.EMPTY;
-
-			return ItemStack.EMPTY;
 		}
 		return remainder;
 	}


### PR DESCRIPTION
Modified the code to make the item voiding feature work only when “doVoiding": true.

I've checked it in my local environment and it seems to work fine, but without understanding the entire codebase, this is just a patch to fix a suspect part, so I'm not sure if there are other things that are broken.